### PR TITLE
Delete First Round Capital, NYC Turing and Knight-Mozilla

### DIFF
--- a/README.md
+++ b/README.md
@@ -258,6 +258,7 @@ Here's a list of some example fellowship programs.  This is by no means a comple
 - [FirstMark Elite](http://firstmarkelite.com/)
 - [Ford-Mozilla Fellows](https://advocacy.mozilla.org/open-web-fellows/)
 - [hackNY Fellows](http://apply.hackny.org/)
+- [Knight-Mozilla Fellows](https://opennews.org/what/fellowships/info/)
 - [KPCB Fellows](http://kpcbfellows.com/)
 - [Mayfield Fellows Program](http://stvp.stanford.edu/mayfield-fellows-program/)
 - [PennApps Fellows](http://www.pennappsfellows.com/)

--- a/README.md
+++ b/README.md
@@ -256,13 +256,10 @@ Here's a list of some example fellowship programs.  This is by no means a comple
 - [Cansbridge Fellowship](http://www.cansbridgefellowship.com/)
 - [CODE2040](http://code2040.org/)
 - [FirstMark Elite](http://firstmarkelite.com/)
-- [First Round Capital](http://www.university.firstround.com/)
 - [Ford-Mozilla Fellows](https://advocacy.mozilla.org/open-web-fellows/)
 - [hackNY Fellows](http://apply.hackny.org/)
-- [Knight-Mozilla Fellows](http://opennews.org/fellowships/)
 - [KPCB Fellows](http://kpcbfellows.com/)
 - [Mayfield Fellows Program](http://stvp.stanford.edu/mayfield-fellows-program/)
-- [NYC Turing Fellows](http://nycturingfellows.org/)
 - [PennApps Fellows](http://www.pennappsfellows.com/)
 - [True Entrepreneur Corps](http://www.trueventures.com/tec/)
 


### PR DESCRIPTION
* The link to First Round Capital does not work and I can't find any information on the Internet related to this Fellowship either. 
* NYC Turing site does not have any information related to internship or fellowship program.
* The Knight-Mozilla link seem unreachable