### PR TITLE
Add Continuous Integration using awesome_bot

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,4 +3,4 @@ rvm: 2.3.3
 before_script: 
     - gem install awesome_bot
 script:
-    - awesome_bot --allow-redirect README.md --whitelist travis-ci
+    - awesome_bot --allow-redirect README.md

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,4 +3,4 @@ rvm: 2.3.3
 before_script: 
     - gem install awesome_bot
 script:
-    - awesome_bot --allow-redirect README.md
+    - awesome_bot --allow-redirect README.md --whitelist travis-ci

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,6 @@
+language: ruby
+rvm: 2.3.3
+before_script: 
+    - gem install awesome_bot
+script:
+    - awesome_bot README.md

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,4 +3,4 @@ rvm: 2.3.3
 before_script: 
     - gem install awesome_bot
 script:
-    - awesome_bot --allow-redirect README.md
+    - awesome_bot --allow-redirect --allow-ssl README.md

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,4 +3,4 @@ rvm: 2.3.3
 before_script: 
     - gem install awesome_bot
 script:
-    - awesome_bot README.md
+    - awesome_bot --allow-redirect README.md

--- a/README.md
+++ b/README.md
@@ -1,6 +1,11 @@
 Getting a Gig: A Guide
 =============
 
+<!--Badges-->
+<!--CI Badges-->
+[![TravisCI](https://travis-ci.org/abdulhannanali/getting-a-gig.svg?branch=master)](https://travis-ci.org/abdulhannanali/getting-a-gig)
+[![CircleCI](https://circleci.com/gh/abdulhannanali/getting-a-gig.svg?style=svg)](https://circleci.com/gh/abdulhannanali/getting-a-gig)
+
 # Introduction
 
 Hey friends!

--- a/README.md
+++ b/README.md
@@ -3,8 +3,8 @@ Getting a Gig: A Guide
 
 <!--Badges-->
 <!--CI Badges-->
-[![TravisCI](https://travis-ci.org/abdulhannanali/getting-a-gig.svg?branch=master)](https://travis-ci.org/abdulhannanali/getting-a-gig)
-[![CircleCI](https://circleci.com/gh/abdulhannanali/getting-a-gig.svg?style=svg)](https://circleci.com/gh/abdulhannanali/getting-a-gig)
+[![TravisCI](https://travis-ci.org/cassidoo/getting-a-gig.svg?branch=master)](https://travis-ci.org/cassidoo/getting-a-gig)
+[![CircleCI](https://circleci.com/gh/cassidoo/getting-a-gig.svg?style=svg)](https://circleci.com/gh/cassidoo/getting-a-gig)
 
 # Introduction
 

--- a/circle.yml
+++ b/circle.yml
@@ -5,4 +5,4 @@ test:
     pre:
         - gem install awesome_bot
     override:
-        awesome_bot --allow-redirect README.md
+        - awesome_bot --allow-redirect --allow-ssl README.md

--- a/circle.yml
+++ b/circle.yml
@@ -1,0 +1,8 @@
+machine:
+    ruby:
+        version: 2.3.3
+test:
+    pre:
+        - gem install awesome_bot
+    override:
+        awesome_bot --allow-redirect README.md


### PR DESCRIPTION
I stumbled upon this amazing  ruby gem called [awesome_bot](https://github.com/dkhamsing/awesome_bot)  which validates all the links present in the file, currently being used for many of the **Awesome** projects on Github. Adding it using TravisCI and CircleCI will always ensure that all the links are in working condition, and no invalid link is being added to the repository as it will also test the PRs. 

We currently use `allow-redirect` and `allow-ssl` option along with `awesome_bot`, there are some links that do a redirect, but still work fine, we use `allow-ssl` which allows ssl errors cos project euler is having some problem with it's ssl certificate.

The branch being merged has it's badges configured based on this repo, @cassidoo needs to activate CI from websites of CircleCI and TravisCI for this, if you want to merge it.  
