### PR TITLE
Remove Venture for America from Fellowships

### DIFF
--- a/README.md
+++ b/README.md
@@ -285,7 +285,6 @@ Here's a list of some example fellowship programs. This is by no means a complet
 - [8VC Fellows](http://www.8vcfellowship.com/)
 - [Mayfield Fellows Program](http://stvp.stanford.edu/mayfield-fellows-program/)
 - [True Entrepreneur Corps](https://trueventures.com/true-platform/fellowships/tec)
-- [Venture for America](http://ventureforamerica.org/)
 - [Conservation X Labs Epic Fellowships](https://conservationxlabs.com/epic-fellowships)
 - [Pursuit Fellowship ](https://www.pursuit.org/fellowship)
 - [MLH Fellowship](https://fellowship.mlh.io/)


### PR DESCRIPTION
The link doesn't work: http://ventureforamerica.org/

<img width="1222" alt="Screenshot 2025-05-29 at 23 23 30" src="https://github.com/user-attachments/assets/ebb5e9df-c36e-406c-808b-09cdee627a98" />
